### PR TITLE
Remove duplicate store declaration

### DIFF
--- a/src/lib/store/hooks.ts
+++ b/src/lib/store/hooks.ts
@@ -1,6 +1,5 @@
-import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
-import { AppDispatch } from '.';
-import { RootState } from './rootReducer';
+import { useDispatch, useSelector } from 'react-redux';
+import { AppDispatch, RootState } from './store';
 
-export const useAppDispatch = () => useDispatch<AppDispatch>();
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
+export const useAppSelector = useSelector.withTypes<RootState>();

--- a/src/lib/store/index.ts
+++ b/src/lib/store/index.ts
@@ -1,13 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit';
-import { useDispatch } from 'react-redux';
-import { rootReducer } from './rootReducer';
 
-export const store = configureStore({
-    reducer: rootReducer,
-})
-
-export type AppDispatch = typeof store.dispatch;
-export const useAppDispatch: () => AppDispatch = useDispatch;
 
 export * from './appConfig/appConfigSelectors';
 export * from './devices/devicesSelectors';
@@ -16,3 +7,6 @@ export * from './runtimeConfig/runtimeSelectors';
 export * from './ui/uiSelectors';
 
 export * from './ui/ui.slice';
+export * from './hooks';
+
+export * from './store';

--- a/src/lib/store/rooms/roomsSelectors.ts
+++ b/src/lib/store/rooms/roomsSelectors.ts
@@ -3,7 +3,7 @@ import { RoomVolumeType, Volume } from 'src/lib/types';
 import { DisplayState, LevelControlsState, RoomConfiguration } from "src/lib/types/state/state";
 import { useGetAllDevices } from '../devices/devicesSelectors';
 import { useAppSelector } from "../hooks";
-import store, { RootState } from '../rootReducer';
+import {store, RootState } from '../store';
 
 export const useRoomConfiguration: (roomKey: string) => RoomConfiguration | undefined = (roomKey: string) =>
   useAppSelector((state) =>

--- a/src/lib/store/runtimeConfig/runtimeConfig.slice.ts
+++ b/src/lib/store/runtimeConfig/runtimeConfig.slice.ts
@@ -2,7 +2,7 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { RoomData } from '../../types/index';
 import { devicesActions } from '../devices/devices.slice';
 import { roomsActions } from '../rooms/rooms.slice';
-import store from '../rootReducer';
+import { store } from '../store';
 
 const initialState: RuntimeConfigState = {
     apiVersion: '',

--- a/src/lib/store/store.ts
+++ b/src/lib/store/store.ts
@@ -5,7 +5,7 @@ import { roomsReducer } from './rooms/rooms.slice';
 import { runtimeConfigReducer } from './runtimeConfig/runtimeConfig.slice';
 import { uiReducer } from './ui/ui.slice';
 
-export const rootReducer = combineReducers({
+const rootReducer = combineReducers({
   appConfig: appConfigReducer,
   runtimeConfig: runtimeConfigReducer,
   rooms: roomsReducer,
@@ -13,10 +13,9 @@ export const rootReducer = combineReducers({
   ui: uiReducer,
 })
 
-const store = configureStore({
+export const store = configureStore({
   reducer: rootReducer
 })
 
 export type RootState = ReturnType<typeof store.getState>;
-
-export default store;
+export type AppDispatch = typeof store.dispatch;


### PR DESCRIPTION
Due to the duplicate store declaration, there were 2 different methods of export for the store. Now using the `export const` for the store itself.

Tested with an existing React app and there were no issues, and the duplicate store was removed.