### PR TITLE
fix: remove `class` attribute from div

### DIFF
--- a/src/lib/shared/Buttons/IconButton/IconButton.tsx
+++ b/src/lib/shared/Buttons/IconButton/IconButton.tsx
@@ -60,7 +60,8 @@ export const IconButton = ({
         className={`${iconClassName || classes.iconsm}`}
         {...{ active: showActive, disabled }}
       />}
-      <div className={otherContentClassName}>{otherContent}</div>
+      {otherContentClassName ? <div className={otherContentClassName}>{otherContent}</div> : <div>{otherContent}</div>}
+      
     </button>
   );
 };


### PR DESCRIPTION
If `otherContentClassName` is not specified for the IconButton, there
will not be an empty `class` attribute on the div wrapping
`otherContent`. When there's an empty `class` attribute, it looks like a
class isn't getting correctly applied.
