### PR TITLE
fix: add rooms & devices to `RoomData` type

### DIFF
--- a/src/lib/store/runtimeConfig/runtimeConfig.slice.ts
+++ b/src/lib/store/runtimeConfig/runtimeConfig.slice.ts
@@ -25,6 +25,8 @@ const initialState: RuntimeConfigState = {
                 pepperDashCoreVersion: '',
                 essentialsPlugins: [],
             },
+            rooms: [],
+            devices:[]
         },
         userCode: '',
         qrUrl: '',

--- a/src/lib/types/classes/room-data.ts
+++ b/src/lib/types/classes/room-data.ts
@@ -1,3 +1,5 @@
+import { IKeyName } from "../interfaces";
+
 export interface RoomData {
   clientId: string | number;
   roomKey: string;
@@ -18,4 +20,10 @@ export interface EssentialsConfig {
     pepperDashCoreVersion: string;
     essentialsPlugins: { name: string; version: string }[];
   };
+  rooms: EssentialsRoom[];
+  devices: EssentialsDevice[];
 }
+
+export interface EssentialsRoom extends IKeyName{}
+
+export interface EssentialsDevice extends IKeyName{}


### PR DESCRIPTION
This will allow for getting room & device keys & names from the `useRuntimeConfig` hook.