### PR TITLE
Add isMic property and update deprecation notice in interfaces

### DIFF
--- a/src/lib/types/state/AudioControlPointListItemBase.ts
+++ b/src/lib/types/state/AudioControlPointListItemBase.ts
@@ -6,4 +6,5 @@ export interface AudioControlPointListItemBase {
   preferredName: string;
   includeInUserList: boolean;
   order: number;
+  isMic?: boolean;
 }

--- a/src/lib/types/state/state/DeviceState.ts
+++ b/src/lib/types/state/state/DeviceState.ts
@@ -34,6 +34,7 @@ export interface DeviceState extends IKeyName {
 
   /**
    * For future use
+   * @deprecated This property is deprecated and will be removed in future versions.
    */
   state: unknown;
 


### PR DESCRIPTION
Introduce the optional `isMic` property to the `AudioControlPointListItemBase` interface and update the deprecation notice for the `state` property in the `DeviceState` interface.