### PR TITLE
fix: add missing optional property showRawLevel to AudioControlPointL…

### DIFF
--- a/src/lib/types/state/AudioControlPointListItemBase.ts
+++ b/src/lib/types/state/AudioControlPointListItemBase.ts
@@ -7,4 +7,5 @@ export interface AudioControlPointListItemBase {
   includeInUserList: boolean;
   order: number;
   isMic?: boolean;
+  showRawLevel?: boolean;
 }


### PR DESCRIPTION
…istItemBase interface
This pull request introduces a minor update to the `AudioControlPointListItemBase` interface in `src/lib/types/state/AudioControlPointListItemBase.ts`. The change adds a new optional property, `showRawLevel`, to the interface.