### PR TITLE
volume hook fix

### DIFF
--- a/src/lib/shared/hooks/useDeviceIBasicVolumeWithFeedback.ts
+++ b/src/lib/shared/hooks/useDeviceIBasicVolumeWithFeedback.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useGetDevice } from '../../store';
 import { IBasicVolumeWithFeedbackState } from '../../types/state/state/IBasicVolumeWithFeedbackState';
 import { useIBasicVolumeWithFeedback } from './interfaces/useIBasicVolumeWithFeedback';
@@ -12,5 +13,10 @@ export function useDeviceIBasicVolumeWithFeedback(deviceKey: string) {
 
   const path = `/device/${deviceKey}`;
 
-  return useIBasicVolumeWithFeedback(path, volumeState?.volume);
+  const volume = useMemo(() => {
+    if (!volumeState) return undefined;
+    return volumeState.volume;
+  }, [volumeState]);
+
+  return useIBasicVolumeWithFeedback(path, volume);
 }

--- a/src/lib/shared/hooks/useGetAllDeviceStateFromRoomConfiguration.ts
+++ b/src/lib/shared/hooks/useGetAllDeviceStateFromRoomConfiguration.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useMemo } from 'react';
 import { RoomConfiguration } from '../../types/state/state';
 import { useWebsocketContext } from '../../utils/useWebsocketContext';
 
@@ -7,14 +7,17 @@ import { useWebsocketContext } from '../../utils/useWebsocketContext';
  * and  send messages to the websocket to get the iniital state
  * for each device
  */
-export const useGetAllDeviceStateFromRoomConfiguration = ({
-  config,
-}: {
-  config: RoomConfiguration | undefined;
-}) => {
+export const useGetAllDeviceStateFromRoomConfiguration = (
+  {
+    config,
+  }: {
+    config: RoomConfiguration | undefined;
+  },
+  requestStatus: boolean = true
+) => {
   const { sendMessage } = useWebsocketContext();
 
-  useEffect(() => {
+  return useMemo(() => {
     if (!config) {
       return;
     }
@@ -90,8 +93,12 @@ export const useGetAllDeviceStateFromRoomConfiguration = ({
 
     console.log('requesting state for deviceKeys:', deviceKeysSet);
 
+    if (!requestStatus) return deviceKeysSet;
+
     deviceKeysSet.forEach((dk) => {
       sendMessage(`/device/${dk}/fullStatus`, { deviceKey: dk });
     });
-  }, [config, sendMessage]);
+
+    return deviceKeysSet;
+  }, [config, sendMessage, requestStatus]);
 };


### PR DESCRIPTION
This pull request refactors two hooks to improve performance and flexibility by replacing `useEffect` with `useMemo` and adding new options for controlling behavior. The changes help optimize component rendering and provide more control over when device state requests are sent.

**Performance optimizations:**

* Replaced `useEffect` with `useMemo` in both `useDeviceIBasicVolumeWithFeedback` and `useGetAllDeviceStateFromRoomConfiguration` to prevent unnecessary re-renders and improve performance. (`src/lib/shared/hooks/useDeviceIBasicVolumeWithFeedback.ts`, [[1]](diffhunk://#diff-8e5d04ae41270865516d9e3e080fd6faf7ef8564744b76800d333d5e64aaf5a0R1); `src/lib/shared/hooks/useGetAllDeviceStateFromRoomConfiguration.ts`, [[2]](diffhunk://#diff-8e02330857e85cb686c7d9ce34066a5d87d68c180789388410e942b31fda1040L1-R1)

**API improvements:**

* Added a `requestStatus` parameter to `useGetAllDeviceStateFromRoomConfiguration` to allow conditional sending of device state requests, giving more control to the caller.
* Modified the return value of `useGetAllDeviceStateFromRoomConfiguration` to always return the set of device keys, regardless of whether requests are sent.

**Code clarity:**

* Improved logic in `useDeviceIBasicVolumeWithFeedback` by memoizing the `volume` value, ensuring it updates only when necessary.

- **fix: memoize volume object to ensure refresh when store changes**
- **fix: full status request based on room config is now optional**
