### PR TITLE
chore: remove typesVersions to fix issues with intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,13 +77,6 @@
   "main": "./dist/mobile-control-react-app-core.umd.js",
   "module": "./dist/mobile-control-react-app-core.es.js",
   "types": "./dist/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "*": [
-        "./dist/index.d.ts"
-      ]
-    }
-  },
   "bugs": {
     "url": "https://github.com/PepperDash/mobile-control-react-app-core"
   },


### PR DESCRIPTION
This pull request includes a minor update to the `package.json` file, specifically removing the `typesVersions` field. This simplifies the TypeScript type resolution configuration for the package.