### PR TITLE
fix: update array merging logic in device and room state reducers

### DIFF
--- a/src/lib/store/devices/devices.slice.ts
+++ b/src/lib/store/devices/devices.slice.ts
@@ -3,46 +3,51 @@ import * as _ from 'lodash';
 import { Message } from '../../types';
 import { DeviceState } from '../../types/state/state';
 
-const initialState: Record<string, DeviceState>  = {
-}
+const initialState: Record<string, DeviceState> = {};
 
 const devicesSlice = createSlice({
-    name: 'devices',
-    initialState,
-    reducers: {
-        setDeviceState(state, action:PayloadAction<Message>) {
-            const type = action.payload.type;
-            const key = type.slice(type.lastIndexOf('/') + 1);
+  name: 'devices',
+  initialState,
+  reducers: {
+    setDeviceState(state, action: PayloadAction<Message>) {
+      const type = action.payload.type;
+      const key = type.slice(type.lastIndexOf('/') + 1);
 
-            if(!key) return;
+      if (!key) return;
 
-            // This method solves the issue of multiple layers of properties
-            // and avoids doing a deep copy of the object
-            const content = action.payload.content as DeviceState;
+      // This method solves the issue of multiple layers of properties
+      // and avoids doing a deep copy of the object
+      const content = action.payload.content as DeviceState;
 
-            // Get existing room state
-            const existingState = state[key] ?? {};
+      // Get existing room state
+      const existingState = state[key] ?? {};
 
-            // merge new state with existing
-            const newState = _.merge(existingState, content);
-
-            // overlay the incoming state properties onto the existing item
-            // or create new item
-            state[key] = newState;
-            
-            // Don't return state when using immer
+      // merge new state with existing (replace arrays instead of merging them)
+      const newState = _.mergeWith(
+        {},
+        existingState,
+        content,
+        (_objValue, srcValue) => {
+          if (Array.isArray(srcValue)) return srcValue;
+          return undefined; // fallback to default merge behavior
         },
-        clearDevices() {
-            return initialState;
-        },
+      );
+
+      // overlay the incoming state properties onto the existing item
+      // or create new item
+      state[key] = newState;
+
+      // Don't return state when using immer
     },
-})
-
-
+    clearDevices() {
+      return initialState;
+    },
+  },
+});
 
 // Extract specific action creators to avoid exposing WritableDraft
 export const devicesActions = {
   setDeviceState: devicesSlice.actions.setDeviceState,
-  clearDevices: devicesSlice.actions.clearDevices
+  clearDevices: devicesSlice.actions.clearDevices,
 };
 export const devicesReducer = devicesSlice.reducer;

--- a/src/lib/store/devices/devices.slice.ts
+++ b/src/lib/store/devices/devices.slice.ts
@@ -19,7 +19,7 @@ const devicesSlice = createSlice({
       // and avoids doing a deep copy of the object
       const content = action.payload.content as DeviceState;
 
-      // Get existing room state
+      // Get existing device state
       const existingState = state[key] ?? {};
 
       // merge new state with existing (replace arrays instead of merging them)
@@ -28,7 +28,7 @@ const devicesSlice = createSlice({
         existingState,
         content,
         (_objValue, srcValue) => {
-          if (Array.isArray(srcValue)) return srcValue;
+          if (Array.isArray(srcValue)) return srcValue.slice();
           return undefined; // fallback to default merge behavior
         },
       );

--- a/src/lib/store/rooms/rooms.slice.ts
+++ b/src/lib/store/rooms/rooms.slice.ts
@@ -28,8 +28,11 @@ const roomsSlice = createSlice({
             // Get existing room state
             const existingState = state[key] ?? {};
 
-            // merge new state with existing
-            const newState = _.merge(existingState, content);
+            // merge new state with existing (replace arrays instead of merging them)
+            const newState = _.mergeWith({}, existingState, content, (_objValue, srcValue) => {
+                if (Array.isArray(srcValue)) return srcValue;
+                return undefined; // fallback to default merge behavior
+            });
 
             // overlay the incoming state properties onto the existing item
             // or create new item


### PR DESCRIPTION
This pull request updates the merging logic for device and room state management to ensure arrays are replaced rather than merged, aligning the behavior between both slices. It also includes minor code style improvements and consistency fixes.

**State merging improvements:**

* Updated the merge logic in `devices.slice.ts` and `rooms.slice.ts` so that when merging new state, arrays are replaced instead of being merged, preventing unintended array concatenation. This is achieved by switching from `_.merge` to `_.mergeWith` with a customizer function. [[1]](diffhunk://#diff-7c626e5362d6d0931f3eea145e892de8a2add827204bc151f433d098f4e3ca36L26-R34) [[2]](diffhunk://#diff-75579e2a898125f337ce5f54883d22a35ba87ba75192a3e3fda7205784f7d523L31-R35)

**Code style and consistency:**

* Fixed code style issues in `devices.slice.ts`, such as removing unnecessary whitespace, ensuring consistent formatting, and adding a missing comma in the exported `devicesActions` object. [[1]](diffhunk://#diff-7c626e5362d6d0931f3eea145e892de8a2add827204bc151f433d098f4e3ca36L6-R6) [[2]](diffhunk://#diff-7c626e5362d6d0931f3eea145e892de8a2add827204bc151f433d098f4e3ca36L39-R51)