### PR TITLE
ci updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          registry-url: "https://registry.npmjs.org"
       - name: Get branch name
         id: get_branch
         run: |
@@ -55,7 +54,5 @@ jobs:
           --package=@semantic-release/github \
           -- semantic-release --debug
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_ACCESS_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,13 +38,11 @@ jobs:
           find: "replace-me-prerelease"
           replace: "${{ steps.get_branch.outputs.prerelease }}"
           include: ".releaserc.json"
-      - name: install packages
-        run: npm ci
-      - name: build
-        run: npm run build
-      - name: Deploy to npm
+      - name: install packages & build
         run: |
-          DEBUG=semantic-release:* npx --package=semantic-release \
+          npm ci
+          npm run build
+          npx --package=semantic-release \
           --package=@semantic-release/commit-analyzer \
           --package=@semantic-release/release-notes-generator \
           --package=@semantic-release/changelog \
@@ -52,7 +50,7 @@ jobs:
           --package=conventional-changelog-conventionalcommits \
           --package=@semantic-release/npm \
           --package=@semantic-release/github \
-          -- semantic-release --debug
+          -- semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org"
+    "registry": "https://registry.npmjs.org/"
   },
   "devDependencies": {
     "@reduxjs/toolkit": "^2.0.1",


### PR DESCRIPTION
This pull request mainly updates the npm registry URL formatting in configuration files and streamlines the npm build and release workflow in GitHub Actions. The changes improve consistency in registry URLs and simplify the CI deployment steps.

NPM has restricted the validity length for access tokens in order to provide better security for packages. They've implemented a feature called [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) that allows the Github Action to use OIDC to authenticate and get a short-lived token. This PR updates this repository to use that mechanism for publishing the package to NPM rather than the access token method.

**CI/CD Workflow Improvements:**

* Combined the separate steps for installing packages and building the project into a single step (`install packages & build`) in `.github/workflows/build.yaml`, reducing redundancy and simplifying the workflow.
* Removed explicit debug flags and unnecessary environment variables (`NODE_AUTH_TOKEN`, `NPM_TOKEN`) from the npm deployment step, relying only on GitHub tokens for authentication.

**Configuration Consistency:**

* Updated the `registry` URL in `package.json` to include a trailing slash for consistency (`https://registry.npmjs.org/`).
* Removed the `registry-url` parameter from the `setup-node` step in the GitHub Actions workflow, as it is now redundant with the updated configuration.

- **ci(force-patch): use NPM OIDC instead of access tokens**
- **ci(force-patch): add trailing slash for registry to match requirements for package**
