### PR TITLE
docs: add data flow and interface hook documentation

### DIFF
--- a/docs/action-paths-app-dev.md
+++ b/docs/action-paths-app-dev.md
@@ -1,0 +1,150 @@
+# Action Paths — App Developer Guide
+
+**Relates to:** [Issue #90](https://github.com/PepperDash/mobile-control-react-app-core/issues/90) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+An **action path** is the WebSocket message type string sent from the React app to [PepperDash Essentials](https://github.com/PepperDash/Essentials). It identifies both the target device or room and the command to execute.
+
+---
+
+## Path Formats
+
+| Target                | Format                           | Example                       |
+| --------------------- | -------------------------------- | ----------------------------- |
+| Device command        | `/device/{deviceKey}/{command}`  | `/device/display1/powerOn`    |
+| Room command          | `/room/{roomKey}/{command}`      | `/room/techRoom/source`       |
+| Device status request | `/device/{deviceKey}/fullStatus` | `/device/display1/fullStatus` |
+| Room status request   | `/room/{roomKey}/status`         | `/room/techRoom/status`       |
+
+> `deviceKey` and `roomKey` values come from the room configuration returned at connection time and stored in `runtimeConfig.roomData`.
+
+---
+
+## How to Send Commands
+
+### Option 1 — Interface Hooks (preferred)
+
+Interface hooks abstract message paths and payloads into typed function calls. Each hook corresponds to an Essentials interface implemented by the device.
+
+```tsx
+import { useIHasPowerControl } from 'mobile-control-react-app-core';
+
+function PowerButton({ deviceKey }: { deviceKey: string }) {
+  const power = useIHasPowerControl(deviceKey);
+
+  return (
+    <button onClick={power.powerOn}>Power On</button>
+  );
+}
+```
+
+For hooks that also return state:
+
+```tsx
+import { useILightingScenes } from 'mobile-control-react-app-core';
+import type { LightingScene } from 'mobile-control-react-app-core';
+
+function LightingPanel({ deviceKey }: { deviceKey: string }) {
+  const lighting = useILightingScenes(deviceKey);
+
+  if (!lighting) return null; // device state not yet in store
+
+  return (
+    <>
+      {lighting.lightingState.scenes.map((scene: LightingScene) => (
+        <button key={scene.name} onClick={() => lighting.selectScene(scene)}>
+          {scene.name}
+        </button>
+      ))}
+    </>
+  );
+}
+```
+
+> See [interface-hooks-app-dev.md](./interface-hooks-app-dev.md) for the full hook catalog.
+
+---
+
+### Option 2 — Direct Context (advanced)
+
+For commands not covered by an existing interface hook, call `useWebsocketContext()` directly.
+
+```tsx
+import { useWebsocketContext } from 'mobile-control-react-app-core';
+
+function CustomControl({ deviceKey }: { deviceKey: string }) {
+  const { sendMessage, sendSimpleMessage } = useWebsocketContext();
+
+  // Arbitrary object payload
+  const sendRoute = () =>
+    sendMessage(`/device/${deviceKey}/route`, {
+      inputKey: 'hdmi1',
+      outputKey: 'display1',
+      routeType: 'AudioVideo',
+    });
+
+  // Simple scalar payload — wrapped automatically as { value }
+  const setLevel = () =>
+    sendSimpleMessage(`/device/${deviceKey}/level`, 75);
+
+  return <button onClick={sendRoute}>Route</button>;
+}
+```
+
+#### Context API Reference
+
+| Function             | Signature                                                    | Payload sent    |
+| -------------------- | ------------------------------------------------------------ | --------------- |
+| `sendMessage`        | `(type: string, content: unknown) => void`                   | `content` as-is |
+| `sendSimpleMessage`  | `(type: string, value: boolean \| number \| string) => void` | `{ value }`     |
+| `addEventHandler`    | `(eventType, key, callback) => void`                         | —               |
+| `removeEventHandler` | `(eventType, key) => void`                                   | —               |
+| `reconnect`          | `() => void`                                                 | —               |
+
+---
+
+## Subscribing to Events
+
+The `/event/` message prefix is used for one-off server-pushed events that are not persistent state (e.g., shutdown timer ticks, user code changes).
+
+```tsx
+import { useEffect } from 'react';
+import { useWebsocketContext } from 'mobile-control-react-app-core';
+
+function ShutdownTimer() {
+  const { addEventHandler, removeEventHandler } = useWebsocketContext();
+
+  useEffect(() => {
+    addEventHandler('/event/shutdownTimer', 'myComponent', (msg) => {
+      console.log('Shutdown timer event', msg.content);
+    });
+    return () => removeEventHandler('/event/shutdownTimer', 'myComponent');
+  }, [addEventHandler, removeEventHandler]);
+
+  return null;
+}
+```
+
+- The `key` string (second argument) must be unique per subscriber — use the component name or a stable ID.
+- Clean up handlers on unmount to avoid stale callbacks.
+
+---
+
+## Flow
+
+```mermaid
+flowchart LR
+    A([User Interaction]) --> B[Component]
+    B --> C{Interface Hook\nor Context}
+    C -->|"sendMessage(path, content)"| D[Redux Action\nwsSendMessage]
+    D --> E[WebSocket Middleware]
+    E -->|"{ type, clientId, content }"| F[(WebSocket)]
+    F --> G[Essentials Backend]
+```
+
+---
+
+## Notes
+
+- `MobileControlProvider` must wrap your component tree — it sets up the Redux store and `WebsocketContext`.
+- Commands are dropped silently when `websocket.isConnected` is `false` — the middleware logs a warning.
+- The `clientId` is injected by the middleware automatically from `runtimeConfig.roomData.clientId`; you never need to set it manually.

--- a/docs/action-paths-contributors.md
+++ b/docs/action-paths-contributors.md
@@ -1,0 +1,162 @@
+# Action Paths — Contributor Reference
+
+**Relates to:** [Issue #90](https://github.com/PepperDash/mobile-control-react-app-core/issues/90) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+Internal architecture for how messages travel from React components to [PepperDash Essentials](https://github.com/PepperDash/Essentials) over WebSocket.
+
+**Key source:** `src/lib/store/middleware/websocketMiddleware.ts`
+
+---
+
+## Wire Format
+
+Every outbound WebSocket frame is a JSON-serialized object:
+
+```json
+{
+  "type": "/device/{deviceKey}/{command}",
+  "clientId": "abc123",
+  "content": { ... }
+}
+```
+
+- `type` — the action path (message routing key)
+- `clientId` — injected by middleware from `runtimeConfig.roomData.clientId`
+- `content` — arbitrary payload; `null` for command-only messages
+
+---
+
+## Redux Middleware Action Types
+
+Defined in `websocketMiddleware.ts` and re-exported from `src/lib/store/index.ts`:
+
+| Constant                  | Creator                                 | Purpose                                    |
+| ------------------------- | --------------------------------------- | ------------------------------------------ |
+| `WS_CONNECT`              | `wsConnect()`                           | Initiate connection sequence               |
+| `WS_DISCONNECT`           | `wsDisconnect()`                        | Close socket with code 4100                |
+| `WS_SEND_MESSAGE`         | `wsSendMessage(type, content)`          | Send a message over the open socket        |
+| `WS_ADD_EVENT_HANDLER`    | `wsAddEventHandler(eventType, key, cb)` | Register a `/event/` listener              |
+| `WS_REMOVE_EVENT_HANDLER` | `wsRemoveEventHandler(eventType, key)`  | Remove a `/event/` listener                |
+| `WS_RECONNECT`            | `wsReconnect()`                         | Navigate to gateway URL to re-authenticate |
+
+---
+
+## Connection Initialization Sequence
+
+Triggered by `wsConnect()`, dispatched on `WebsocketProvider` mount.
+
+```mermaid
+sequenceDiagram
+    participant App as React App
+    participant MW as WS Middleware
+    participant HTTP as HTTP (Axios)
+    participant WS as WebSocket
+    participant ES as Essentials
+
+    App->>MW: wsConnect()
+    MW->>MW: Read token from URL ?token= or sessionStorage
+    MW->>HTTP: GET /_local-config/_config.local.json
+    HTTP-->>MW: { apiPath, ... }
+    MW->>MW: dispatch(appConfigActions.setAppConfig)
+    MW->>HTTP: GET {apiPath}/version
+    HTTP-->>MW: { apiVersion, serverIsRunningOnProcessorHardware, ... }
+    MW->>MW: dispatch(runtimeConfigActions.setRuntimeConfig)
+    MW->>HTTP: GET {apiPath}/ui/joinroom?token={token}
+    HTTP-->>MW: { clientId, roomKey, systemUuid, config, ... }
+    MW->>MW: dispatch(runtimeConfigActions.setRoomData)
+    MW->>WS: new WebSocket("{apiPath}/ui/join/{token}?clientId={clientId}")
+    WS-->>MW: onopen
+    MW->>MW: dispatch(runtimeConfigActions.setWebsocketIsConnected(true))
+    MW->>WS: send { type: "/room/{roomKey}/status", clientId, content: null }
+    WS->>ES: Initial room status request
+    ES-->>WS: /room/{roomKey} state message
+```
+
+---
+
+## Outbound Message Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Component
+    participant H as Interface Hook
+    participant CTX as WebsocketContext
+    participant MW as WS Middleware
+    participant WS as WebSocket
+    participant ES as Essentials
+
+    C->>H: call action fn (e.g. powerOn())
+    H->>CTX: sendMessage("/device/{key}/powerOn", null)
+    CTX->>MW: dispatch(wsSendMessage(type, content))
+    MW->>MW: read clientId from runtimeConfig.roomData
+    MW->>WS: WebSocket.send(JSON.stringify({ type, clientId, content }))
+    WS->>ES: frame delivered
+```
+
+---
+
+## sendMessage Implementation
+
+```typescript
+// WebsocketProvider.tsx — dispatches the Redux action
+const sendMessage = (type: string, content: SimpleContent | unknown) => {
+  dispatch(wsSendMessage(type, content));
+};
+
+// websocketMiddleware.ts — middleware handles WS_SEND_MESSAGE
+const sendMessage = (messageType, content, getState) => {
+  const { isConnected } = getState().runtimeConfig.websocket;
+  const { clientId } = getState().runtimeConfig.roomData;
+
+  if (state.client && isConnected) {
+    state.client.send(JSON.stringify({ type: messageType, clientId, content }));
+  } else {
+    console.warn('WebSocket middleware: Cannot send message - not connected');
+  }
+};
+```
+
+---
+
+## WebSocket Close Codes
+
+| Code   | Trigger                            | Auto-Reconnect | Behavior                                                                                      |
+| ------ | ---------------------------------- | -------------- | --------------------------------------------------------------------------------------------- |
+| `1000` | Normal close                       | Yes            | Standard server close; starts reconnection loop                                               |
+| `4000` | User code changed                  | No             | Clears state; shows user-code entry UI                                                        |
+| `4001` | Processor disconnect / room change | Conditional    | Reconnects if `touchpanelKey` present or running on processor hardware; otherwise shows error |
+| `4002` | Room combination changed           | No             | Clears state; shows reconnect prompt                                                          |
+| `4100` | Client-initiated close             | No             | `wsDisconnect()` was called; no reconnection                                                  |
+
+---
+
+## Reconnection Loop
+
+- On disconnect (non-4100, non-4000, non-4002): `startReconnectionLoop(dispatch)` schedules a `wsConnect()` after **5000 ms**
+- The loop runs until a successful `onopen` event, at which point `stopReconnectionLoop()` cancels the timer
+- `wsReconnect()` (manual reconnect button) navigates to the gateway URL to re-authenticate using `systemUuid`, `roomKey`, and optional `userCode`
+
+---
+
+## State Cleared on Disconnect
+
+When the socket closes (except code 4100), the middleware dispatches:
+
+- `uiActions.setShowReconnect(true)`
+- `runtimeConfigActions.setWebsocketIsConnected(false)`
+- `devicesActions.clearDevices()`
+- `roomsActions.clearRooms()`
+- `uiActions.clearAllModals()`
+- `uiActions.clearSyncState()`
+
+---
+
+## Adding a New Outbound Message Type
+
+No middleware changes are needed for new message paths. The path string is passed directly through `wsSendMessage`. To add a new action:
+
+1. Create an interface hook in `src/lib/shared/hooks/interfaces/useI{InterfaceName}.ts`
+2. Call `sendMessage(`/device/${key}/{command}`, payload)` inside the hook
+3. Export from `src/lib/shared/hooks/interfaces/index.ts`
+
+See [interface-hooks-contributors.md](./interface-hooks-contributors.md) for the full authoring guide.

--- a/docs/action-paths-contributors.md
+++ b/docs/action-paths-contributors.md
@@ -67,6 +67,8 @@ sequenceDiagram
     MW->>WS: new WebSocket("{apiPath}/ui/join/{token}?clientId={clientId}")
     WS-->>MW: onopen
     MW->>MW: dispatch(runtimeConfigActions.setWebsocketIsConnected(true))
+    MW->>MW: Listener observes setWebsocketIsConnected/setRoomData
+    MW->>MW: requestRoomStatus()
     MW->>WS: send { type: "/room/{roomKey}/status", clientId, content: null }
     WS->>ES: Initial room status request
     ES-->>WS: /room/{roomKey} state message
@@ -140,7 +142,9 @@ const sendMessage = (messageType, content, getState) => {
 
 ## State Cleared on Disconnect
 
-When the socket closes (except code 4100), the middleware dispatches:
+The middleware has two distinct disconnect paths based on close code:
+
+**No-reconnect path** (codes `4100`, `4000`, `4002`, and `4001` without a touchpanel key on non-processor hardware) — calls `clearStateDataOnDisconnect()`, which dispatches:
 
 - `uiActions.setShowReconnect(true)`
 - `runtimeConfigActions.setWebsocketIsConnected(false)`
@@ -148,6 +152,16 @@ When the socket closes (except code 4100), the middleware dispatches:
 - `roomsActions.clearRooms()`
 - `uiActions.clearAllModals()`
 - `uiActions.clearSyncState()`
+
+**Auto-reconnect path** (normal closes such as `1000`, and `4001` with a touchpanel key or running on processor hardware) — does **not** dispatch `setShowReconnect(true)`. It dispatches:
+
+- `runtimeConfigActions.setWebsocketIsConnected(false)`
+- `devicesActions.clearDevices()`
+- `roomsActions.clearRooms()`
+- `uiActions.clearAllModals()`
+- `uiActions.clearSyncState()`
+
+…and then starts the reconnection loop.
 
 ---
 

--- a/docs/device-state-feedback-app-dev.md
+++ b/docs/device-state-feedback-app-dev.md
@@ -86,12 +86,18 @@ function RoomPower({ roomKey }: { roomKey: string }) {
 ## Reading Connection State
 
 ```tsx
-import { useRuntimeConfig } from 'mobile-control-react-app-core';
+import {
+  useRoomKey,
+  useWsIsConnected,
+  useClientId,
+  useSystemUuid,
+} from 'mobile-control-react-app-core';
 
-// Individual selectors from runtimeConfig hooks
-const roomKey = useCurrentRoomKey();
+// Individual hooks from runtimeConfig
+const roomKey = useRoomKey();
 const isConnected = useWsIsConnected();
-const roomData = useRoomData();      // clientId, config, deviceInterfaceSupport
+const clientId = useClientId();       // clientId for the current session
+const systemUuid = useSystemUuid();   // unique identifier for the Crestron processor
 ```
 
 ---

--- a/docs/device-state-feedback-app-dev.md
+++ b/docs/device-state-feedback-app-dev.md
@@ -1,0 +1,167 @@
+# Device State & Feedback — App Developer Guide
+
+**Relates to:** [Issue #91](https://github.com/PepperDash/mobile-control-react-app-core/issues/91) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+Device state and room state are pushed from [Essentials](https://github.com/PepperDash/Essentials) over WebSocket and stored in a Redux store. Components read state via selector hooks — when state updates, components re-render automatically.
+
+---
+
+## Redux Store Shape
+
+```
+store
+├── appConfig       — static app config loaded from _config.local.json
+├── runtimeConfig   — connection state, roomData, clientId, roomKey
+├── rooms           — Record<roomKey, RoomState>
+├── devices         — Record<deviceKey, DeviceState>
+└── ui              — modal visibility, error messages, sync state
+```
+
+---
+
+## Reading Device State
+
+### `useGetDevice<T>(deviceKey)`
+
+Returns the full state object for a device, or `undefined` if not yet received.
+
+```tsx
+import { useGetDevice } from 'mobile-control-react-app-core';
+import type { DisplayState } from 'mobile-control-react-app-core';
+
+function DisplayStatus({ deviceKey }: { deviceKey: string }) {
+  const display = useGetDevice<DisplayState>(deviceKey);
+
+  if (!display) return <span>Loading...</span>;
+
+  return <span>Power: {display.powerState ? 'On' : 'Off'}</span>;
+}
+```
+
+- Pass the TypeScript interface as a generic (`<DisplayState>`) to get typed access.
+- Returns `undefined` until the first state message for that device key arrives.
+
+### `useGetAllDevices()`
+
+Returns `Record<string, DeviceState>` — the full devices slice.
+
+---
+
+## Reading Room State
+
+### `useRoomState<T>(roomKey)` / `useGetRoom<T>(roomKey)`
+
+These are aliases. Returns the full room state or `undefined`.
+
+```tsx
+import { useRoomState } from 'mobile-control-react-app-core';
+
+function RoomPower({ roomKey }: { roomKey: string }) {
+  const room = useRoomState(roomKey);
+  return <span>{room?.isOn ? 'Room On' : 'Room Off'}</span>;
+}
+```
+
+### Room Selector Hooks
+
+| Hook                                   | Returns                                             |
+| -------------------------------------- | --------------------------------------------------- |
+| `useRoomState(roomKey)`                | Full room state                                     |
+| `useRoomConfiguration(roomKey)`        | Static room config (devices, sources, destinations) |
+| `useRoomVolume(roomKey, volumeKey)`    | `Volume` object for a named zone                    |
+| `useRoomLevelControls(roomKey)`        | `LevelControlsState` for the room                   |
+| `useRoomName(roomKey)`                 | Room display name string                            |
+| `useRoomIsOn(roomKey)`                 | `boolean`                                           |
+| `useRoomInCall(roomKey)`               | `boolean`                                           |
+| `useRoomIsWarmingUp(roomKey)`          | `boolean`                                           |
+| `useRoomIsCoolingDown(roomKey)`        | `boolean`                                           |
+| `useRoomSourceList(roomKey)`           | Array of available sources                          |
+| `useRoomDestinations(roomKey)`         | Destination map                                     |
+| `useRoomDestinationList(roomKey)`      | Array of destinations                               |
+| `useRoomEnvironmentalDevices(roomKey)` | Environmental device keys                           |
+| `useRoomShareState(roomKey)`           | Sharing/presentation state                          |
+
+---
+
+## Reading Connection State
+
+```tsx
+import { useRuntimeConfig } from 'mobile-control-react-app-core';
+
+// Individual selectors from runtimeConfig hooks
+const roomKey = useCurrentRoomKey();
+const isConnected = useWsIsConnected();
+const roomData = useRoomData();      // clientId, config, deviceInterfaceSupport
+```
+
+---
+
+## Requesting State on Mount
+
+By default, the middleware requests room status (`/room/{key}/status`) immediately after connection. For individual device state, use `useGetAllDeviceStateFromRoomConfiguration`:
+
+```tsx
+import {
+  useRoomConfiguration,
+  useGetAllDeviceStateFromRoomConfiguration,
+} from 'mobile-control-react-app-core';
+
+function RoomPanel({ roomKey }: { roomKey: string }) {
+  const config = useRoomConfiguration(roomKey);
+
+  // Sends /device/{key}/fullStatus for every device key in the room config
+  useGetAllDeviceStateFromRoomConfiguration({ config });
+
+  return <div>...</div>;
+}
+```
+
+- Sends `fullStatus` requests once per mount (guarded by a `useRef`).
+- Pass `requestStatus={false}` to suppress the requests when you only need to observe state.
+
+---
+
+## Subscribing to Events
+
+For transient events that are not stored in state (e.g., shutdown timer ticks):
+
+```tsx
+import { useEffect } from 'react';
+import { useWebsocketContext } from 'mobile-control-react-app-core';
+
+function ShutdownTimer({ roomKey }: { roomKey: string }) {
+  const { addEventHandler, removeEventHandler } = useWebsocketContext();
+
+  useEffect(() => {
+    addEventHandler(`/event/shutdownTimer`, 'ShutdownTimer', (msg) => {
+      console.log('Timer event', msg.content);
+    });
+    return () => removeEventHandler(`/event/shutdownTimer`, 'ShutdownTimer');
+  }, [addEventHandler, removeEventHandler]);
+}
+```
+
+---
+
+## State Update Flow
+
+```mermaid
+flowchart LR
+    A[Essentials Backend] -->|WebSocket frame| B[WS Middleware\nonmessage]
+    B -->|"/device/*"| C[devicesActions.setDeviceState]
+    B -->|"/room/*"| D[roomsActions.setRoomState]
+    C --> E[(Redux Store\ndevices slice)]
+    D --> F[(Redux Store\nrooms slice)]
+    E --> G[useGetDevice selector]
+    F --> H[useRoomState selector]
+    G --> I([Component re-renders])
+    H --> I
+```
+
+---
+
+## Notes
+
+- **State merges incrementally.** Essentials sends partial state updates; they are deep-merged with existing state. Arrays are replaced entirely.
+- **Keys are case-sensitive.** `deviceKey` and `roomKey` strings must match exactly what Essentials sends.
+- **Interface hooks handle state access internally.** Hooks like `useILightingScenes` and `useIBasicVolumeWithFeedback` call `useGetDevice` themselves — you typically do not need to call the selector separately when using a hook.

--- a/docs/device-state-feedback-contributors.md
+++ b/docs/device-state-feedback-contributors.md
@@ -103,7 +103,7 @@ setDeviceState(state, action: PayloadAction<Message>) {
 
 **Source:** `src/lib/store/rooms/rooms.slice.ts`
 
-Identical merge strategy to `setDeviceState`. Key extracted from the last segment of `message.type`.
+Similar merge strategy to `setDeviceState`: room state is deep-merged by key, and arrays in new content replace existing arrays rather than being merged element-by-element. The key is extracted from the last segment of `message.type`. Note: unlike the devices slice which clones incoming arrays with `.slice()`, the rooms slice returns the array reference directly.
 
 **Additional behavior:** `setRoomState` is also called for `fullStatus` responses from the room.
 

--- a/docs/device-state-feedback-contributors.md
+++ b/docs/device-state-feedback-contributors.md
@@ -1,0 +1,199 @@
+# Device State & Feedback — Contributor Reference
+
+**Relates to:** [Issue #91](https://github.com/PepperDash/mobile-control-react-app-core/issues/91) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+Internal architecture for how state messages from [Essentials](https://github.com/PepperDash/Essentials) Messengers flow into the Redux store and surface in React components.
+
+**Key sources:**
+- `src/lib/store/middleware/websocketMiddleware.ts`
+- `src/lib/store/devices/devices.slice.ts`
+- `src/lib/store/rooms/rooms.slice.ts`
+- `src/lib/store/runtimeConfig/runtimeConfig.slice.ts`
+
+---
+
+## End-to-End Feedback Flow
+
+```mermaid
+sequenceDiagram
+    participant ES as Essentials Messenger
+    participant WS as WebSocket
+    participant MW as WS Middleware (onmessage)
+    participant RX as Redux Dispatch
+    participant SL as Redux Slice
+    participant SEL as Selector Hook
+    participant C as Component
+
+    ES->>WS: JSON frame { type, content }
+    WS->>MW: onmessage event
+    MW->>MW: parse message, route by type prefix
+    MW->>RX: dispatch action based on prefix
+    RX->>SL: reducer runs, merges new state
+    SL-->>SEL: store state updated
+    SEL-->>C: selector returns new value, component re-renders
+```
+
+---
+
+## Message Routing
+
+The middleware routes every incoming frame based on the `type` field prefix:
+
+```typescript
+// websocketMiddleware.ts — onmessage handler
+if (message.type === 'close') {
+  newWs.close(4001, message.content as string);
+} else if (message.type.startsWith('/system/')) {
+  // handled by switch statement (see System Messages below)
+} else if (message.type.startsWith('/event/')) {
+  // dispatched to registered event handler callbacks
+} else if (message.type.startsWith('/room/')) {
+  dispatch(roomsActions.setRoomState(message));
+} else if (message.type.startsWith('/device/')) {
+  dispatch(devicesActions.setDeviceState(message));
+}
+```
+
+---
+
+## System Messages
+
+System messages update `runtimeConfig` slice or trigger side effects:
+
+| `message.type`                   | `message.content` type                                      | Effect                                                      |
+| -------------------------------- | ----------------------------------------------------------- | ----------------------------------------------------------- |
+| `/system/touchpanelKey`          | `string`                                                    | `runtimeConfigActions.setTouchpanelKey`                     |
+| `/system/roomKey`                | `string`                                                    | Clears rooms + devices; `setCurrentRoomKey`                 |
+| `/system/userCodeChanged`        | `{ userCode, qrUrl }`                                       | `runtimeConfigActions.setUserCode`                          |
+| `/system/roomCombinationChanged` | `string`                                                    | `window.location.reload()`                                  |
+| `/system/deviceInterfaces`       | `{ deviceInterfaces: Record<string, DeviceInterfaceInfo> }` | Merges into `runtimeConfig.roomData.deviceInterfaceSupport` |
+
+---
+
+## Device State Reducer (`setDeviceState`)
+
+**Source:** `src/lib/store/devices/devices.slice.ts`
+
+```typescript
+setDeviceState(state, action: PayloadAction<Message>) {
+  // Extract key from message type: "/device/{key}" → key
+  const key = action.payload.type.slice(action.payload.type.lastIndexOf('/') + 1);
+  const content = action.payload.content as DeviceState;
+
+  // Deep merge: new content overlays existing state
+  // Arrays in new content replace (not merge) the existing array
+  const newState = _.mergeWith({}, state[key], content, (_objValue, srcValue) => {
+    if (Array.isArray(srcValue)) return srcValue.slice();
+    return undefined; // let mergeWith handle objects recursively
+  });
+
+  state[key] = newState;
+}
+```
+
+**Key behaviors:**
+- Keyed by the last segment of `message.type` (e.g., `/device/display1` → `display1`)
+- Deep merge: Essentials can send partial updates — only changed properties need to be sent
+- **Arrays replace entirely** — no array element merging
+- `clearDevices()` resets the entire devices slice to `{}` (called on disconnect and room key change)
+
+---
+
+## Room State Reducer (`setRoomState`)
+
+**Source:** `src/lib/store/rooms/rooms.slice.ts`
+
+Identical merge strategy to `setDeviceState`. Key extracted from the last segment of `message.type`.
+
+**Additional behavior:** `setRoomState` is also called for `fullStatus` responses from the room.
+
+---
+
+## runtimeConfig Slice
+
+Tracks connection lifecycle and session data:
+
+```typescript
+interface RuntimeConfigState {
+  apiVersion: string;
+  serverIsRunningOnProcessorHardware: boolean | undefined;
+  websocket: { isConnected?: boolean };
+  pluginVersion: string;
+  disconnectionMessage: string;
+  token: string;
+  currentRoomKey: string;
+  touchpanelKey: string;
+  roomData: {
+    clientId: string;
+    roomKey: string;
+    systemUuid: string;
+    roomUuid: string;
+    userAppUrl: string;
+    userCode: string;
+    qrUrl: string;
+    config: {
+      runtimeInfo: { pluginVersion, essentialsVersion, pepperDashCoreVersion, essentialsPlugins };
+      rooms: string[];
+      devices: string[];
+    };
+    deviceInterfaceSupport: Record<string, DeviceInterfaceInfo>;
+  };
+}
+```
+
+| Reducer                          | Trigger                             |
+| -------------------------------- | ----------------------------------- |
+| `setRuntimeConfig`               | HTTP GET `/version` response        |
+| `setRoomData`                    | HTTP GET `/ui/joinroom` response    |
+| `setWebsocketIsConnected(bool)`  | `onopen` (true) / `onclose` (false) |
+| `setCurrentRoomKey(key)`         | `/system/roomKey` message           |
+| `setTouchpanelKey(key)`          | `/system/touchpanelKey` message     |
+| `setDeviceInterfaces(map)`       | `/system/deviceInterfaces` message  |
+| `setUserCode({userCode, qrUrl})` | `/system/userCodeChanged` message   |
+
+---
+
+## State Request Pattern
+
+Components request device state on mount by sending `fullStatus` messages:
+
+```typescript
+// useGetAllDeviceStateFromRoomConfiguration.ts
+deviceKeysSet.forEach((dk) => {
+  sendMessage(`/device/${dk}/fullStatus`, { deviceKey: dk });
+});
+```
+
+- The middleware sends `/room/{roomKey}/status` automatically after WebSocket connects.
+- Individual device state must be explicitly requested via `/device/{key}/fullStatus`.
+- Essentials responds by pushing a `/device/{key}` message with the full state object.
+
+---
+
+## Event Handler System
+
+Event handlers are stored in middleware state (not Redux state) because callbacks are not serializable:
+
+```typescript
+// Middleware state (local, not in Redux)
+state.eventHandlers: Record<string, Record<string, (data: Message) => void>>
+//                          eventType        key        callback
+```
+
+- `wsAddEventHandler(eventType, key, callback)` — adds a callback to the in-memory map
+- `wsRemoveEventHandler(eventType, key)` — removes by eventType + key
+- On message received with `/event/` prefix: all registered callbacks for that `eventType` are invoked
+
+> Note: `wsAddEventHandler` is excluded from Redux's serializable check middleware because callbacks are non-serializable.
+
+---
+
+## Adding Support for a New State Shape
+
+1. Create a TypeScript interface in `src/lib/types/state/state/` (e.g., `MyDeviceState.ts`)
+2. Export from `src/lib/types/state/state/index.ts` and `src/lib/types/index.ts`
+3. Essentials sends the state under `/device/{key}` — no middleware changes needed
+4. Components use `useGetDevice<MyDeviceState>(key)` to access the typed state
+5. Create an interface hook in `src/lib/shared/hooks/interfaces/` if actions are needed
+
+See [interface-hooks-contributors.md](./interface-hooks-contributors.md) for the hook authoring guide.

--- a/docs/interface-hooks-app-dev.md
+++ b/docs/interface-hooks-app-dev.md
@@ -97,7 +97,7 @@ function TransportBar({ deviceKey }: { deviceKey: string }) {
 
 | Hook                                                  | Key Type               | Returns                                       | Actions                                                                                         |
 | ----------------------------------------------------- | ---------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `useIBasicVolume(path)`                               | path string            | `IBasicVolumeReturn`                          | `volumeUp`, `volumeDown` (PHR), `muteToggle`                                                    |
+| `useIBasicVolume(path)`                               | path string            | `IBasicVolumeReturn \| undefined`             | `volumeUp`, `volumeDown` (PHR), `muteToggle`                                                    |
 | `useIBasicVolumeWithFeedback(path, volumeState)`      | path + Volume          | `IBasicVolumeWithFeedbackReturn \| undefined` | + `setLevel(number)`, `muteOn`, `muteOff`; includes `volumeState`                               |
 | `useILevelControls(key)`                              | device or room key     | `ILevelControlsReturn \| undefined`           | `setLevel(levelKey, value)`, `muteToggle(levelKey)`, `muteOn`, `muteOff`; includes `levelState` |
 | `useDeviceIBasicVolume(deviceKey)`                    | device key             | `IBasicVolumeReturn \| undefined`             | Convenience wrapper — builds path as `/device/{key}`                                            |
@@ -111,13 +111,13 @@ function TransportBar({ deviceKey }: { deviceKey: string }) {
 
 ### Transport / Media Playback
 
-| Hook                         | Key Type   | Returns                   | Actions                                                                                        |
-| ---------------------------- | ---------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
-| `useITransport(key)`         | device key | `ITransportProps`         | `play`, `pause`, `stop`, `prevTrack`, `nextTrack`, `rewind`, `fastForward`, `record` (all PHR) |
-| `useIChannel(key)`           | device key | `IChannelMessengerProps`  | `channelUp`, `channelDown`, `lastChannel`, `guide`, `info`, `exit` (all PHR)                   |
-| `useIDvr(key)`               | device key | `IDvrProps`               | `dvrList`, `record` (both PHR)                                                                 |
-| `useINumeric(key)`           | device key | `INumericProps`           | `digit0`–`digit9`, `keypadAccessoryButton1`, `keypadAccessoryButton2` (all PHR)                |
-| `useISetTopBoxControls(key)` | device key | `ISetTopBoxControlsProps` | `dvrList`, `replay` (both PHR)                                                                 |
+| Hook                         | Key Type   | Returns                               | Actions                                                                                        |
+| ---------------------------- | ---------- | ------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `useITransport(key)`         | device key | `ITransportProps \| undefined`        | `play`, `pause`, `stop`, `prevTrack`, `nextTrack`, `rewind`, `fastForward`, `record` (all PHR) |
+| `useIChannel(key)`           | device key | `IChannelMessengerProps \| undefined` | `channelUp`, `channelDown`, `lastChannel`, `guide`, `info`, `exit` (all PHR)                   |
+| `useIDvr(key)`               | device key | `IDvrProps \| undefined`              | `dvrList`, `record` (both PHR)                                                                 |
+| `useINumeric(key)`           | device key | `INumericProps`                       | `digit0`–`digit9`, `keypadAccessoryButton1`, `keypadAccessoryButton2` (all PHR)                |
+| `useISetTopBoxControls(key)` | device key | `ISetTopBoxControlsProps`             | `dvrList`, `replay` (both PHR)                                                                 |
 
 ---
 

--- a/docs/interface-hooks-app-dev.md
+++ b/docs/interface-hooks-app-dev.md
@@ -1,0 +1,244 @@
+# Interface Hooks — App Developer Guide
+
+**Relates to:** [Issue #94](https://github.com/PepperDash/mobile-control-react-app-core/issues/94) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+Interface hooks are the primary API for interacting with Essentials devices from React components. Each hook corresponds to a C# interface implemented by a device in [Essentials](https://github.com/PepperDash/Essentials).
+
+---
+
+## What Interface Hooks Provide
+
+- **Actions** — typed functions that send WebSocket commands to Essentials
+- **State** (on hooks that include feedback) — the current device state from the Redux store, reactively updated
+
+---
+
+## Two Hook Categories
+
+### Action-Only Hooks
+
+No Redux state. Return only action functions. All physical button interactions (press/hold/release) return a `PressHoldReleaseReturn` object.
+
+```tsx
+import { useIHasPowerControl } from 'mobile-control-react-app-core';
+
+function PowerButtons({ deviceKey }: { deviceKey: string }) {
+  const power = useIHasPowerControl(deviceKey);
+
+  return (
+    <>
+      <button onClick={power.powerOn}>On</button>
+      <button onClick={power.powerOff}>Off</button>
+    </>
+  );
+}
+```
+
+### State + Action Hooks
+
+Include current device state alongside actions. Return `undefined` until state arrives from Essentials — always guard for `undefined`.
+
+```tsx
+import { useILightingScenes } from 'mobile-control-react-app-core';
+
+function LightingPanel({ deviceKey }: { deviceKey: string }) {
+  const lighting = useILightingScenes(deviceKey);
+
+  if (!lighting) return null;
+
+  return (
+    <ul>
+      {lighting.lightingState.scenes.map(scene => (
+        <li key={scene.name}>
+          <button onClick={() => lighting.selectScene(scene)}>{scene.name}</button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+---
+
+## Press / Hold / Release Buttons
+
+Hooks using `useButtonHeldHeartbeat` return `PressHoldReleaseReturn`, which provides pointer event handlers for simulating physical button behavior. Spread them onto a button element:
+
+```tsx
+import { useITransport } from 'mobile-control-react-app-core';
+
+function TransportBar({ deviceKey }: { deviceKey: string }) {
+  const transport = useITransport(deviceKey);
+
+  return (
+    <button {...transport.play}>Play</button>
+  );
+}
+```
+
+`PressHoldReleaseReturn` shape:
+```typescript
+{
+  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerUp:   (e: React.PointerEvent) => void;
+  onPointerLeave:(e: React.PointerEvent) => void;
+}
+```
+
+- **Press:** sends `{ value: 'pressed' }` immediately
+- **Held:** sends `{ value: 'held' }` every 250 ms while pointer is down
+- **Release:** sends `{ value: 'released' }` on pointer up or leave
+
+---
+
+## Hook Catalog
+
+### Volume
+
+| Hook                                                  | Key Type               | Returns                                       | Actions                                                                                         |
+| ----------------------------------------------------- | ---------------------- | --------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `useIBasicVolume(path)`                               | path string            | `IBasicVolumeReturn`                          | `volumeUp`, `volumeDown` (PHR), `muteToggle`                                                    |
+| `useIBasicVolumeWithFeedback(path, volumeState)`      | path + Volume          | `IBasicVolumeWithFeedbackReturn \| undefined` | + `setLevel(number)`, `muteOn`, `muteOff`; includes `volumeState`                               |
+| `useILevelControls(key)`                              | device or room key     | `ILevelControlsReturn \| undefined`           | `setLevel(levelKey, value)`, `muteToggle(levelKey)`, `muteOn`, `muteOff`; includes `levelState` |
+| `useDeviceIBasicVolume(deviceKey)`                    | device key             | `IBasicVolumeReturn \| undefined`             | Convenience wrapper — builds path as `/device/{key}`                                            |
+| `useDeviceIBasicVolumeWithFeedback(deviceKey)`        | device key             | `IBasicVolumeWithFeedbackReturn \| undefined` | Convenience wrapper — builds path + reads device volume state                                   |
+| `useRoomIBasicVolume(roomKey)`                        | room key               | `IBasicVolumeReturn \| undefined`             | Convenience wrapper — builds path as `/room/{key}`                                              |
+| `useRoomIBasicVolumeWithFeedback(roomKey, volumeKey)` | room + volume zone key | `IBasicVolumeWithFeedbackReturn \| undefined` | Convenience wrapper — reads room volume state by zone                                           |
+
+> `useIBasicVolume` and `useIBasicVolumeWithFeedback` accept a full path prefix, e.g., `/device/{key}` or `/room/{key}`. The convenience wrappers build that path for you.
+
+---
+
+### Transport / Media Playback
+
+| Hook                         | Key Type   | Returns                   | Actions                                                                                        |
+| ---------------------------- | ---------- | ------------------------- | ---------------------------------------------------------------------------------------------- |
+| `useITransport(key)`         | device key | `ITransportProps`         | `play`, `pause`, `stop`, `prevTrack`, `nextTrack`, `rewind`, `fastForward`, `record` (all PHR) |
+| `useIChannel(key)`           | device key | `IChannelMessengerProps`  | `channelUp`, `channelDown`, `lastChannel`, `guide`, `info`, `exit` (all PHR)                   |
+| `useIDvr(key)`               | device key | `IDvrProps`               | `dvrList`, `record` (both PHR)                                                                 |
+| `useINumeric(key)`           | device key | `INumericProps`           | `digit0`–`digit9`, `keypadAccessoryButton1`, `keypadAccessoryButton2` (all PHR)                |
+| `useISetTopBoxControls(key)` | device key | `ISetTopBoxControlsProps` | `dvrList`, `replay` (both PHR)                                                                 |
+
+---
+
+### Power & Display
+
+| Hook                                  | Key Type   | Returns                                          | Actions                                                                                                                       |
+| ------------------------------------- | ---------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `useIHasPowerControl(key)`            | device key | `IHasPowerWithFeedbackProps`                     | `powerOn`, `powerOff`, `powerToggle`                                                                                          |
+| `useTwoWayDisplayBase(key)`           | device key | `TwoWayDisplayBaseReturn \| undefined`           | Composite: `powerControl` (useIHasPowerControl) + `inputControl` (useIHasSelectableItems); includes `displayState`, `powerFb` |
+| `useISwitchedOutput(key)`             | device key | `ISwitchedOutputReturn \| undefined`             | `on`, `off`; includes `switchedOutputState`                                                                                   |
+| `useIProjectorScreenLiftControl(key)` | device key | `IProjectorScreenLiftControlReturn \| undefined` | `raise`, `lower`; includes `projectorScreenLiftControlState`                                                                  |
+
+---
+
+### Routing & Switching
+
+| Hook                                  | Key Type   | Returns                                     | Actions                                                                       |
+| ------------------------------------- | ---------- | ------------------------------------------- | ----------------------------------------------------------------------------- |
+| `useIRunRouteAction(roomKey)`         | room key   | `IRunRouteActionProps \| undefined`         | `runRoute({ sourceListItemKey, sourceListKey? })`; includes `routingState`    |
+| `useIRunDirectRouteAction(roomKey)`   | room key   | `IRunDirectRouteActionProps`                | `runDirectRoute({ sourceKey, destinationKey, signalType })`                   |
+| `useIRunDefaultPresentRoute(roomKey)` | room key   | `IRunDefaultPresentRouteProps`              | `runDefaultPresentRoute()`                                                    |
+| `useIMatrixRouting(key)`              | device key | `IMatrixRoutingReturn \| undefined`         | `setRoute({ inputKey, outputKey, routeType })`; includes `matrixRoutingState` |
+| `useIHasSelectableItems<T>(key)`      | device key | `IHasSelectableItemsReturn<T> \| undefined` | `selectItem(itemKey)`; includes `itemsState`                                  |
+
+---
+
+### Cameras
+
+| Hook                  | Key Type   | Returns                          | Actions                                                                                                |
+| --------------------- | ---------- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `useCameraBase(key)`  | device key | `CameraBaseProps \| undefined`   | `up`, `down`, `left`, `right`, `zoomIn`, `zoomOut` (all PHR), `recallPreset(number)`; includes `state` |
+| `useIHasCameras(key)` | device key | `IHasCamerasReturn \| undefined` | `selectCamera(cameraKey)`; includes `state`                                                            |
+
+---
+
+### Lighting & Environment
+
+| Hook                           | Key Type   | Returns                                  | Actions                                                                             |
+| ------------------------------ | ---------- | ---------------------------------------- | ----------------------------------------------------------------------------------- |
+| `useILightingScenes(key)`      | device key | `ILightingScenesReturn \| undefined`     | `selectScene(scene: LightingScene)`; includes `lightingState`                       |
+| `useIShadesOpenCloseStop(key)` | device key | `IShadesOpenCloseStopProps \| undefined` | `shadeUp`, `shadeDown`, `stopOrPreset`; includes `shadeState`                       |
+| `useITemperatureSensor(key)`   | device key | `ITemperatureSensorReturn \| undefined`  | `setTemperatureUnitsToCelcius`, `setTemperatureUnitsToFahrenheit`; includes `state` |
+| `useIHumiditySensor(key)`      | device key | `IHumiditySensorReturn \| undefined`     | State-only; includes `state: ITHumiditySensorState`                                 |
+| `useIColor(key)`               | device key | `IColorProps \| undefined`               | `red`, `green`, `yellow`, `blue` (all PHR) — colored button functions               |
+
+---
+
+### Room Combiner
+
+| Hook                              | Key Type   | Returns                                      | Actions                                                                                                                                                     |
+| --------------------------------- | ---------- | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useIEssentialsRoomCombiner(key)` | device key | `IEssentialsRoomCombinerReturn \| undefined` | `setAutoMode`, `setManualMode`, `toggleMode`, `togglePartitionState(partitionKey)`, `setRoomCombinationScenario(scenarioKey)`; includes `roomCombinerState` |
+
+---
+
+### Room Controls
+
+| Hook                               | Key Type | Returns                                   | Actions                                                                                                              |
+| ---------------------------------- | -------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `useIShutdownPromptTimer(roomKey)` | room key | `IShutdownPromptTimerReturn \| undefined` | `setShutdownPromptSeconds(n)`, `shutdownStart`, `shutdownEnd`, `shutdownCancel`; includes `shutdownPromptTimerState` |
+| `useIRoomEventSchedule(key)`       | room key | `IRoomEventScheduleReturn \| undefined`   | `save(events: ScheduleEvent[])`; includes `roomEventScheduleState`                                                   |
+
+---
+
+### Presets
+
+| Hook                         | Key Type   | Returns                                | Actions                                                                                                                         |
+| ---------------------------- | ---------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `useDevicePresetsModel(key)` | device key | `DevicePresetsModelProps \| undefined` | `recallPreset(deviceKey, preset: PresetChannel)`, `savePresets(presets: PresetChannel[])`; includes `state: DevicePresetsState` |
+| `useIDspPresets(key)`        | device key | `{ recallPreset }`                     | `recallPreset(presetKey: string \| IKeyName)` — sends `/device/{key}/recallPreset`                                              |
+
+---
+
+### AV & Surround
+
+| Hook                           | Key Type   | Returns                                   | Actions                                                                                                                                   |
+| ------------------------------ | ---------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `useAvrControl(key)`           | device key | `AvrReturn \| undefined`                  | Composite: `powerControl`, `inputControl`, `surroundSoundModes`, `surroundChannels`, `mainVolumeControl`; includes `avrState: PowerState` |
+| `useIHasSurroundChannels(key)` | device key | `IHasSurroundChannelsReturn \| undefined` | `setDefaultChannelLevels()`, `getFullStatus()`; includes `levelControls: Record<string, Volume>`                                          |
+
+---
+
+### Codec / Conference
+
+| Hook                                           | Key Type   | Returns        | Actions                                                     |
+| ---------------------------------------------- | ---------- | -------------- | ----------------------------------------------------------- |
+| `useIMcCiscoCodecUserInterfaceAppControl(key)` | device key | `{ closeApp }` | `closeApp()` — sends `/device/{key}/closeWebViewController` |
+
+---
+
+### System & Utility
+
+| Hook                                        | Key Type       | Returns                                                | Actions                                                                                                                                                                        |
+| ------------------------------------------- | -------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useITechPassword(roomKey)`                 | room key       | `ITechPasswordReturn \| undefined`                     | `validatePassword(password: string)`, `setPassword(oldPassword, newPassword)`; includes `techPasswordState`; events: `passwordChangedSuccessfully`, `passwordValidationResult` |
+| `useITheme(touchpanelKey)`                  | touchpanel key | `IThemeReturn`                                         | `saveTheme(theme: string)`; includes `currentTheme?: string`                                                                                                                   |
+| `useIDPad(key)`                             | device key     | `IDPadProps \| undefined`                              | `up`, `down`, `left`, `right`, `select`, `menu`, `exit` (all PHR)                                                                                                              |
+| `useIDeviceInfoMessenger(key)`              | device key     | `DeviceInfo \| undefined`                              | State-only; returns `device.deviceInfo` directly (not wrapped in object)                                                                                                       |
+| `useICommunicationMonitor(key)`             | device key     | `ICommunicationMonitorReturn \| undefined`             | State-only; includes `communicationMonitorState: CommunicationMonitorState`                                                                                                    |
+| `useEndpoint(key)`                          | device key     | `IEndpointReturn \| undefined`                         | State-only; includes `endpointState: EndpointState`                                                                                                                            |
+| `useMobileControlTouchpanelController(key)` | device key     | `MobileControlTouchpanelControllerReturn \| undefined` | `appControl: { hideApp, openApp, closeApp }`, `zoomControl: { endCall }`; includes `touchpanelState: MobileControlTouchpanelState`                                             |
+| `useSystemControl()`                        | none           | `{ reboot, programReset }`                             | `reboot()` — `/system/reboot`; `programReset()` — `/system/programReset`                                                                                                       |
+
+---
+
+## Hook Return Types at a Glance
+
+```mermaid
+flowchart TD
+    A[Interface Hook] --> B{Includes State?}
+    B -->|No| C[Action-Only\nAlways returns value\nNever undefined]
+    B -->|Yes| D[State + Action\nReturns undefined\nuntil device state arrives]
+    C --> E[Spread PHR props onto button\nor call action functions directly]
+    D --> F[Guard: if !hook return null\nThen render state + bind actions]
+```
+
+---
+
+## Notes
+
+- Hooks can only be called inside components wrapped by `MobileControlProvider`.
+- State+action hooks return `undefined` when the device key is not yet in the Redux store. This is expected — the state arrives asynchronously after connection.
+- `PressHoldReleaseReturn` props (`onPointerDown`, `onPointerUp`, `onPointerLeave`) must be spread onto an HTML element with pointer event support. Use `<button>` or `<div>` with `touch-action: none` in CSS.
+- For volume controls, use the convenience wrappers (`useDeviceIBasicVolumeWithFeedback`, `useRoomIBasicVolumeWithFeedback`) rather than calling `useIBasicVolumeWithFeedback` directly — they handle path construction and state selection automatically.

--- a/docs/interface-hooks-contributors.md
+++ b/docs/interface-hooks-contributors.md
@@ -15,7 +15,7 @@ Guide for authoring new interface hooks in `src/lib/shared/hooks/interfaces/`.
 
 - File: `useI{EssentialsInterfaceName}.ts`
 - Function: `useI{EssentialsInterfaceName}(key: string)`
-- Return interface: `I{EssentialsInterfaceName}Return`
+- Return interface: `I{EssentialsInterfaceName}Return` (new hooks use `*Return`; legacy hooks in this directory may use `*Props` — do not rename existing interfaces)
 - The name must match the C# interface in [Essentials](https://github.com/PepperDash/Essentials) (e.g., `IHasPowerControl` → `useIHasPowerControl`)
 
 ---

--- a/docs/interface-hooks-contributors.md
+++ b/docs/interface-hooks-contributors.md
@@ -1,0 +1,233 @@
+# Interface Hooks — Contributor Guide
+
+**Relates to:** [Issue #94](https://github.com/PepperDash/mobile-control-react-app-core/issues/94) · [Document Mobile Control data flow #89](https://github.com/PepperDash/mobile-control-react-app-core/issues/89)
+
+Guide for authoring new interface hooks in `src/lib/shared/hooks/interfaces/`.
+
+**Key sources:**
+- `src/lib/shared/hooks/interfaces/` — all existing hooks
+- `src/lib/shared/hooks/useButtonHeldHeartbeat.ts`
+- `src/lib/shared/hooks/usePressHoldRelease.ts`
+
+---
+
+## Naming Convention
+
+- File: `useI{EssentialsInterfaceName}.ts`
+- Function: `useI{EssentialsInterfaceName}(key: string)`
+- Return interface: `I{EssentialsInterfaceName}Return`
+- The name must match the C# interface in [Essentials](https://github.com/PepperDash/Essentials) (e.g., `IHasPowerControl` → `useIHasPowerControl`)
+
+---
+
+## Internal Architecture
+
+```mermaid
+flowchart TD
+    A[Component] --> B[Interface Hook]
+    B --> C[useWebsocketContext]
+    B --> D[useGetDevice / useRoomState]
+    C --> E[sendMessage / sendSimpleMessage]
+    E --> F[Redux wsSendMessage action]
+    D --> G[Redux selector]
+    F --> H[WS Middleware → Essentials]
+    G --> I[Current device state from store]
+```
+
+---
+
+## Pattern 1 — Action-Only Hook
+
+Use when the Essentials interface has no feedback state (commands only).
+
+```typescript
+// src/lib/shared/hooks/interfaces/useIHasPowerControl.ts
+import { useWebsocketContext } from '../../../utils/useWebsocketContext';
+
+export function useIHasPowerControl(key: string): IHasPowerWithFeedbackProps {
+  const { sendMessage } = useWebsocketContext();
+
+  const powerOn = () => sendMessage(`/device/${key}/powerOn`, null);
+  const powerOff = () => sendMessage(`/device/${key}/powerOff`, null);
+  const powerToggle = () => sendMessage(`/device/${key}/powerToggle`, null);
+
+  return { powerOn, powerOff, powerToggle };
+}
+
+export interface IHasPowerWithFeedbackProps {
+  powerOn: () => void;
+  powerOff: () => void;
+  powerToggle: () => void;
+}
+```
+
+**Rules:**
+- Never returns `undefined` — actions are always available
+- Use `sendMessage(path, null)` for command-only messages
+- Use `sendSimpleMessage(path, value)` for scalar payloads (wraps as `{ value }`)
+- Use `sendMessage(path, object)` for structured payloads
+
+---
+
+## Pattern 2 — State + Action Hook
+
+Use when the Essentials interface has both commands and feedback state.
+
+```typescript
+// src/lib/shared/hooks/interfaces/useILightingScenes.ts
+import { useGetDevice } from '../../../store';
+import { LightingScene, LightingState } from '../../../types';
+import { useWebsocketContext } from '../../../utils/useWebsocketContext';
+
+export function useILightingScenes(key: string): ILightingScenesReturn | undefined {
+  const { sendMessage } = useWebsocketContext();
+  const state = useGetDevice<LightingState>(key);
+
+  // Return undefined until state arrives — component must guard for this
+  if (!state) return undefined;
+
+  const setScene = (scene: LightingScene) =>
+    sendMessage(`/device/${key}/selectScene`, scene);
+
+  return { lightingState: state, selectScene: setScene };
+}
+
+export interface ILightingScenesReturn {
+  lightingState: LightingState;
+  selectScene: (scene: LightingScene) => void;
+}
+```
+
+**Rules:**
+- Return type must be `ReturnType | undefined`
+- Guard with `if (!state) return undefined;` before building actions
+- Use `useGetDevice<T>(key)` for device state; `useRoomState<T>(key)` for room state
+- The state type (`LightingState`) must be defined in `src/lib/types/state/state/`
+
+---
+
+## Pattern 3 — Press / Hold / Release Hook
+
+Use when the Essentials interface has physical-button-style commands (press, hold, release).
+
+```typescript
+// src/lib/shared/hooks/interfaces/useITransport.ts
+import { useButtonHeldHeartbeat } from '../useButtonHeldHeartbeat';
+import { PressHoldReleaseReturn } from '../usePressHoldRelease';
+
+export function useITransport(key: string): ITransportProps {
+  const path = `/device/${key}`;
+
+  const play  = useButtonHeldHeartbeat(path, 'play');
+  const pause = useButtonHeldHeartbeat(path, 'pause');
+  const stop  = useButtonHeldHeartbeat(path, 'stop');
+
+  return { play, pause, stop };
+}
+
+export interface ITransportProps {
+  play:  PressHoldReleaseReturn;
+  pause: PressHoldReleaseReturn;
+  stop:  PressHoldReleaseReturn;
+}
+```
+
+**`useButtonHeldHeartbeat(path, command)` behavior:**
+- `onPointerDown` → sends `{ value: 'pressed' }` to `{path}/{command}`, then sends `{ value: 'held' }` every **250 ms**
+- `onPointerUp` / `onPointerLeave` → sends `{ value: 'released' }`, clears the interval
+
+**When to use `usePressHoldRelease` directly:**
+Use `usePressHoldRelease` (lower level) when you need `onHold` or `onPressedButNotHeld` callbacks without the automatic heartbeat — for example, long-press to reveal a menu.
+
+---
+
+## Path Conventions
+
+| Target                     | Path                             |
+| -------------------------- | -------------------------------- |
+| Device command             | `` `/device/${key}/{command}` `` |
+| Room command               | `` `/room/${key}/{command}` ``   |
+| Camera command (exception) | `` `/camera/{command}` ``        |
+
+> Most hooks take `key: string` and build the full path internally. Some hooks accept a pre-built `path` string (e.g., `useIBasicVolume`) for flexibility between device and room targets.
+
+---
+
+## State Type Requirements
+
+For a state+action hook, the device state type must:
+
+1. Live in `src/lib/types/state/state/{TypeName}.ts`
+2. Extend `DeviceState` (or `RoomState` for room-scoped interfaces)
+3. Be exported from `src/lib/types/state/state/index.ts`
+4. Be exported from `src/lib/types/index.ts`
+
+```typescript
+// src/lib/types/state/state/MyDeviceState.ts
+import { DeviceState } from './DeviceState';
+
+export interface MyDeviceState extends DeviceState {
+  isActive: boolean;
+  level: number;
+}
+```
+
+---
+
+## Export Requirements
+
+After creating a hook, add it to both export files:
+
+### `src/lib/shared/hooks/interfaces/index.ts`
+```typescript
+export * from './useIMyNewInterface';
+```
+
+### `src/lib/shared/hooks/interfaces/interfaceNames.ts`
+Add the interface name to the `InterfaceNames` union type if it corresponds to a named Essentials interface:
+```typescript
+export type InterfaceNames =
+  | "IBasicVolumeWithFeedback"
+  | "IMyNewInterface"       // ← add here
+  | string;
+```
+
+---
+
+## Composite Hooks
+
+When a device or component needs multiple interfaces combined, build a composite hook that calls the individual interface hooks internally:
+
+```typescript
+// useTwoWayDisplayBase.ts — combines power + input selection + state
+export function useTwoWayDisplayBase(key: string): TwoWayDisplayBaseReturn | undefined {
+  const displayState = useGetDevice<DisplayState>(key);
+  const powerControl = useIHasPowerControl(key);         // action-only
+  const inputControl = useIHasSelectableItems<IHasInputsState>(key); // state+action
+
+  if (!displayState) return undefined;
+
+  const powerOnFb  = (displayState.powerState || displayState.isWarming) && !displayState.isCooling;
+  const powerOffFb = (!displayState.powerState || displayState.isCooling) && !displayState.isWarming;
+
+  return { displayState, powerControl, inputControl: inputControl!, powerFb: { powerOnFb, powerOffFb } };
+}
+```
+
+**Rules for composite hooks:**
+- Name with the Essentials base class, not an interface (e.g., `useTwoWayDisplayBase`, `useCameraBase`)
+- Guard on the primary state object; delegate action logic to the constituent hooks
+- Do not duplicate `sendMessage` calls that are already in a constituent hook
+
+---
+
+## Checklist for New Interface Hooks
+
+- [ ] File in `src/lib/shared/hooks/interfaces/useI{InterfaceName}.ts`
+- [ ] Function name matches Essentials interface exactly
+- [ ] Exported return interface defined in the same file
+- [ ] State type (if needed) defined in `src/lib/types/state/state/`
+- [ ] Exported from `src/lib/shared/hooks/interfaces/index.ts`
+- [ ] Interface name added to `interfaceNames.ts` (if applicable)
+- [ ] `npm run build` passes with no errors
+- [ ] `npm run lint` passes with 0 warnings


### PR DESCRIPTION
- docs/action-paths-app-dev.md — how to send commands from components
- docs/action-paths-contributors.md — WS init sequence, wire format, close codes
- docs/device-state-feedback-app-dev.md — reading device/room state in components
- docs/device-state-feedback-contributors.md — onmessage routing, merge strategy, runtimeConfig
- docs/interface-hooks-app-dev.md — full hook catalog with return types and actions
- docs/interface-hooks-contributors.md — patterns and checklist for authoring new hooks

Closes #90
Closes #91
Closes #94